### PR TITLE
Update CI

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
       The name for the CircuitPython repo.  The default is 'circuitpython-repo',
       and there typically isn't any reason to change this unless it conflicts
       with an existing folder name in your repository.
-    required: truehttps://github.com/adafruit/Adafruit_CircuitPython_turtle/pull/31
+    required: true
     default: 'circuitpython-repo'
   mpy-directory:
     description: >

--- a/action.yml
+++ b/action.yml
@@ -191,10 +191,11 @@ runs:
           rm $file
         done
     - name: Upload ZIP file to release
-      uses: csexton/release-asset-action@master
+      uses: shogo82148/actions-upload-release-asset@v1
       with:
-        file: ${{ inputs.zip-filename }}
-        github-token: ${{ inputs.github-token }}
+        asset_path: ${{ inputs.zip-filename }}
+        github_token: ${{ inputs.github-token }}
+        upload_url: ${{ github.event.release.upload_url }}
     - name: Delete ZIP file
       shell: bash
       run: |


### PR DESCRIPTION
- Updates GitHub Actions step that attaches release assets to avoid deprecation
- Fixed botched metadata with stray link