### PR TITLE
Fix for fetch-all-submodules

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Examples
 ========
 
 If you have just a repository with files intended for a CircuitPython board, your release
-file could be very simple!  This release CI creates .mpy files for CircuitPython 7.2.0:
+file could be very simple!  This release CI creates .mpy files for CircuitPython 8.2.0:
 
 .. code-block:: yaml
 
@@ -55,7 +55,7 @@ file could be very simple!  This release CI creates .mpy files for CircuitPython
           uses: adafruit/build-mpy@v1
           with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
-            circuitpy-tag: "7.2.0"
+            circuitpy-tag: "8.2.0"
 
 You also have granular control of which directories to compile and zip and the ability to specify which
 files should or should not be compiled and/or zipped.  For example, if you wanted to compile and zip
@@ -80,7 +80,7 @@ to specify certain files NOT to compile, you could modify the script above to be
           uses: adafruit/build-mpy@v1
           with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
-            circuitpy-tag: "7.2.0"
+            circuitpy-tag: "8.2.0"
             mpy-directory: "microcontroller"
             mpy-manifest-file: "mpy_manifest.txt"
             mpy-manifest-type: "exclude"

--- a/action.yml
+++ b/action.yml
@@ -84,10 +84,19 @@ runs:
     - name: Enter CircuitPython repo, checkout tag, and update
       shell: bash
       run: |
+        function version() {
+          echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }';
+        }
+
         cd ${{ inputs.circuitpython-repo-name }}
         git fetch
         git checkout ${{ inputs.circuitpy-tag }}
-        make fetch-submodules
+
+        if [ $(version "${{ inputs.circuitpy-tag }}") -ge $(version "8.2.0") ]; then
+          make fetch-all-submodules
+        else
+          make fetch-submodules
+        fi
     - name: Build mpy-cross
       shell: bash
       run: |


### PR DESCRIPTION
Added a version check and if the version is >= 8.2.0 it uses fetch-all-submodules otherwise it uses fetch-submodules. #7 

Tested against CircuitPython Tags: 
- 7.2.0
- 8.2.0
- 8.2.0-beta.1
- 8.2.4