### PR TITLE
Update to use pre compiled mpy-cross binaries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,9 +20,8 @@ Inputs
      Argument Name                                 Description                                       Default                              Notes
 ======================= ===================================================================== ==================== =====================================================================
 github-token            Your GitHub token                                                     N/A                  N/A
-circuitpy-tag           The version of CircuitPython to compile for                           N/A                  You can use any valid tag (or branch) from ``adafruit/circuitpython``
+mpy-cross-version       The version of mpy-cross to download and use                          8.0.5                You can specify any version from ``https://adafruit-circuit-python.s3.amazonaws.com/index.html?prefix=bin/mpy-cross``
 zip-filename            The name of the ZIP file that will be attached                        "mpy-release.zip"    N/A
-circuitpython-repo-name The name of the clone CircuitPython repo                              "circuitpython-repo" Change if it conflicts with another file
 mpy-directory           The directory to search for files to compile                          "." (top folder)     Becomes the basis for filepaths in ``mpy-manifest-file``
 mpy-manifest-file       A file with a list of files to compile or exclude                     ""                   If none is given, all files in ``mpy-directory`` are used
 mpy-manifest-type       Whether the files in the manifest file should be included or excluded "include"            N/A
@@ -35,7 +34,7 @@ Examples
 ========
 
 If you have just a repository with files intended for a CircuitPython board, your release
-file could be very simple!  This release CI creates .mpy files for CircuitPython 8.2.0:
+file could be very simple!  
 
 .. code-block:: yaml
 
@@ -48,19 +47,19 @@ file could be very simple!  This release CI creates .mpy files for CircuitPython
         runs-on: ubuntu-latest
         steps:
         - name: Checkout the current repo
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
           with:
             submodules: true
         - name: Run MPY Action
-          uses: adafruit/build-mpy@v1
+          uses: adafruit/build-mpy@v2
           with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
-            circuitpy-tag: "8.2.0"
 
 You also have granular control of which directories to compile and zip and the ability to specify which
-files should or should not be compiled and/or zipped.  For example, if you wanted to compile and zip
-files in a folder named ``microcontroller`` and you wanted to use a manifest file named ``mpy_manifest.txt``
-to specify certain files NOT to compile, you could modify the script above to be:
+files should or should not be compiled and/or zipped as well as the ability to specify a different mpy-cross
+For example, if you wanted to compile and zip files in a folder named ``microcontroller`` and you wanted to 
+use a manifest file named ``mpy_manifest.txt`` to specify certain files NOT to compile, using mpy-cross 
+version ``7.3.1``, you could modify the script above to be:
 
 .. code-block:: yaml
 
@@ -73,14 +72,14 @@ to specify certain files NOT to compile, you could modify the script above to be
         runs-on: ubuntu-latest
         steps:
         - name: Checkout the current repo
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
           with:
             submodules: true
         - name: Run MPY Action
-          uses: adafruit/build-mpy@v1
+          uses: adafruit/build-mpy@v2
           with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
-            circuitpy-tag: "8.2.0"
+            mpy-cross-version: "7.3.1"
             mpy-directory: "microcontroller"
             mpy-manifest-file: "mpy_manifest.txt"
             mpy-manifest-type: "exclude"

--- a/action.yml
+++ b/action.yml
@@ -80,6 +80,7 @@ runs:
     - name: Compile MPY files
       shell: bash
       run: |
+        echo "Compiling using mpy-cross version ${{ inputs.mpy-cross-version }}"
         # Read MPY manifest file contents, if needed
         if [[ "${{ inputs.mpy-manifest-file }}" != "" ]]
         then

--- a/action.yml
+++ b/action.yml
@@ -8,20 +8,14 @@ inputs:
   github-token:
     description: 'Your GitHub token, needed to upload the ZIP file'
     required: true
-  circuitpy-tag:
-    description: 'The CircuitPython version of mpy-cross to build'
+  mpy-cross-version:
+    description: 'The version of mpy-cross to use'
     required: true
+    default: "8.0.5"
   zip-filename:
     description: 'The name of the ZIP file to attach'
     required: true
     default: "mpy-release.zip"
-  circuitpython-repo-name:
-    description: >
-      The name for the CircuitPython repo.  The default is 'circuitpython-repo',
-      and there typically isn't any reason to change this unless it conflicts
-      with an existing folder name in your repository.
-    required: true
-    default: 'circuitpython-repo'
   mpy-directory:
     description: >
       The directory to look for files to compile with mpy-cross.  If none
@@ -76,40 +70,16 @@ runs:
         sudo apt install build-essential
         sudo add-apt-repository ppa:pybricks/ppa
         sudo apt install git gettext uncrustify
-    - name: Clone adafruit/circuitpython
-      uses: actions/checkout@v3
-      with:
-        repository: adafruit/circuitpython
-        path: ${{ inputs.circuitpython-repo-name }}
-    - name: Enter CircuitPython repo, checkout tag, and update
-      if: ${{ false }}
-      shell: bash
-      run: |
-        function version() {
-          echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }';
-        }
-        cd ${{ inputs.circuitpython-repo-name }}
-        git fetch
-        git checkout ${{ inputs.circuitpy-tag }}
-
-        if [ $(version "${{ inputs.circuitpy-tag }}") -ge $(version "8.2.0") ]; then
-          make fetch-all-submodules
-        else
-          make fetch-submodules
-        fi
     - name: Download mpy-cross
       shell: bash
       run: |
         mkdir mpy-cross
         cd mpy-cross
-        wget -O mpy-cross https://adafruit-circuit-python.s3.amazonaws.com/bin/mpy-cross/mpy-cross.static-amd64-linux-8.0.5
+        wget -O mpy-cross https://adafruit-circuit-python.s3.amazonaws.com/bin/mpy-cross/mpy-cross.static-amd64-linux-${{ inputs.mpy-cross-version }}
         chmod +x mpy-cross
     - name: Compile MPY files
       shell: bash
       run: |
-        # Store repo name
-        # reponame="${{ inputs.circuitpython-repo-name }}"
-
         # Read MPY manifest file contents, if needed
         if [[ "${{ inputs.mpy-manifest-file }}" != "" ]]
         then

--- a/action.yml
+++ b/action.yml
@@ -96,7 +96,7 @@ runs:
         # Compile MPY files
         mpyresults=()
         prempyfiles=()
-        pyfiles=$(find ${{ inputs.mpy-directory }} -name "*.py" ! -path "./${{ inputs.circuitpython-repo-name }}/*" ! -name "code.py" -printf '%P\n')
+        pyfiles=$(find ${{ inputs.mpy-directory }} -name "*.py" ! -name "code.py" -printf '%P\n')
         for file in ${pyfiles[@]}
         do
           if [[ "${{ inputs.mpy-manifest-file }}" == "" ]] || \
@@ -111,10 +111,6 @@ runs:
             mpy-cross/mpy-cross $prempyfile -o $outputmpy
           fi
         done
-
-        # Delete the CircuitPython repo
-        echo "Deleting CircuitPython repository folder"
-        rm -r ${{ inputs.circuitpython-repo-name }}
 
         # Read ZIP manifest file contents, if needed
         if [[ "${{ inputs.zip-manifest-file }}" != "" ]]

--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
         cd ${{ inputs.circuitpython-repo-name }}
         git fetch
         git checkout ${{ inputs.circuitpy-tag }}
-        make fetch-submodules
+        make fetch-all-submodules
     - name: Build mpy-cross
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -82,6 +82,7 @@ runs:
         repository: adafruit/circuitpython
         path: ${{ inputs.circuitpython-repo-name }}
     - name: Enter CircuitPython repo, checkout tag, and update
+      if: ${{ false }}
       shell: bash
       run: |
         function version() {
@@ -96,17 +97,18 @@ runs:
         else
           make fetch-submodules
         fi
-    - name: Build mpy-cross
+    - name: Download mpy-cross
       shell: bash
       run: |
-        cd ${{ inputs.circuitpython-repo-name }}/mpy-cross
-        make clean
-        make
+        mkdir mpy-cross
+        cd mpy-cross
+        wget -O mpy-cross https://adafruit-circuit-python.s3.amazonaws.com/bin/mpy-cross/mpy-cross.static-amd64-linux-8.0.5
+        chmod +x mpy-cross
     - name: Compile MPY files
       shell: bash
       run: |
         # Store repo name
-        reponame="${{ inputs.circuitpython-repo-name }}"
+        # reponame="${{ inputs.circuitpython-repo-name }}"
 
         # Read MPY manifest file contents, if needed
         if [[ "${{ inputs.mpy-manifest-file }}" != "" ]]
@@ -136,7 +138,7 @@ runs:
             mpyresults+=("$outputmpy")
             prempyfile="${{ inputs.mpy-directory }}/$file"
             prempyfiles+=("$prempyfile")
-            ${reponame}/mpy-cross/mpy-cross $prempyfile -o $outputmpy
+            mpy-cross/mpy-cross $prempyfile -o $outputmpy
           fi
         done
 


### PR DESCRIPTION
build-mpy stopped working and compiling the CircutPython version so I made the changes indicated in #17.  I removed the CircuitPython checkout and replaced it with pulling the default (current 8.0.5) version of mpy-cross.  I also added the ability to specify a specific version of mpy-cross. 

